### PR TITLE
Contigs Filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The development of this pipeline is part of the GPS Project ([Global Pneumococca
   | Option | Values | Description |
   | --- | ---| --- |
   | `--assembler` | `"shovill"` or `"unicycler"`<br />(Default: `"shovill"`)| SPAdes Assembler to assemble the reads. |
+  | `--min_contig_length` | Any integer value<br />(Default: `500`) | Minimum legnth of contig to be included in the assembly |
 
 ## Mapping
   | Option | Values | Description |

--- a/bin/assembly_qc.sh
+++ b/bin/assembly_qc.sh
@@ -1,6 +1,6 @@
 # Extract assembly QC information and determine QC result based on report.tsv from Quast, total base count
 
-CONTIGS=$(awk -F'\t' '$1 == "# contigs" { print $2 }' $REPORT)
+CONTIGS=$(awk -F'\t' '$1 == "# contigs (>= 0 bp)" { print $2 }' $REPORT)
 LENGTH=$(awk -F'\t' '$1 == "Total length" { print $2 }' $REPORT)
 DEPTH=$(printf %.2f $(echo "$BASES / $LENGTH" | bc -l) )
 

--- a/modules/assembly.nf
+++ b/modules/assembly.nf
@@ -10,6 +10,7 @@ process ASSEMBLY_UNICYCLER {
 
     input:
     tuple val(sample_id), path(read1), path(read2), path(unpaired)
+    val min_contig_length
 
     output:
     tuple val(sample_id), path(fasta)
@@ -17,7 +18,7 @@ process ASSEMBLY_UNICYCLER {
     script:
     fasta="${sample_id}.contigs.fasta"
     """
-    unicycler -1 "$read1" -2 "$read2" -s "$unpaired" -o results -t `nproc`
+    unicycler -1 "$read1" -2 "$read2" -s "$unpaired" -o results -t `nproc` --min_fasta_length "$min_contig_length"
     mv results/assembly.fasta "${fasta}"
     """
 }
@@ -34,6 +35,7 @@ process ASSEMBLY_SHOVILL {
 
     input:
     tuple val(sample_id), path(read1), path(read2), path(unpaired)
+    val min_contig_length
 
     output:
     tuple val(sample_id), path(fasta)
@@ -41,7 +43,7 @@ process ASSEMBLY_SHOVILL {
     script:
     fasta="${sample_id}.contigs.fasta"
     """
-    shovill --R1 "$read1" --R2 "$read2" --outdir results --cpus `nproc`
+    shovill --R1 "$read1" --R2 "$read2" --outdir results --cpus `nproc` --minlen "$min_contig_length"
     mv results/contigs.fa "${fasta}"
     """
 }

--- a/modules/info.nf
+++ b/modules/info.nf
@@ -325,17 +325,18 @@ process SAVE {
     |╚══════════╧════════════════════════════════════════════════════════════════════════════════╝
     |""".stripMargin()
 
-    def moduleTextRow = { leftContent, rightContent ->
-        textRow(15, 71, leftContent, rightContent)
+    def assemblerTextRow = { leftContent, rightContent ->
+        textRow(25, 61, leftContent, rightContent)
     }
 
-    String moduleText = """\
-    |┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Module Selection ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
-    |╔═════════════════╤═════════════════════════════════════════════════════════════════════════╗
-    |${moduleTextRow('Module', 'Selection')}
-    |╠═════════════════╪═════════════════════════════════════════════════════════════════════════╣
-    |${moduleTextRow('Assembler', params.assembler.capitalize())}
-    |╚═════════════════╧═════════════════════════════════════════════════════════════════════════╝
+    String assemblerText = """\
+    |┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Assembler Options ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
+    |╔═══════════════════════════╤═══════════════════════════════════════════════════════════════╗
+    |${assemblerTextRow('Option', 'Value')}
+    |╠═══════════════════════════╪═══════════════════════════════════════════════════════════════╣
+    |${assemblerTextRow('Selected Assembler', params.assembler.capitalize())}
+    |${assemblerTextRow('Minimum contig length', params.min_contig_length)}
+    |╚═══════════════════════════╧═══════════════════════════════════════════════════════════════╝
     |""".stripMargin()
 
     def qcTextRow = { leftContent, rightContent ->
@@ -368,7 +369,7 @@ process SAVE {
         """\
         |${coreText}
         |${ioText}
-        |${moduleText}
+        |${assemblerText}
         |${qcText}
         |${dbText}
         |${toolText}

--- a/modules/validate.nf
+++ b/modules/validate.nf
@@ -6,6 +6,7 @@ validParams = [
     reads: 'path_exist',
     output: 'path',
     assembler: 'assembler',
+    min_contig_length: 'int',
     seroba_remote: 'url_git',
     seroba_local: 'path',
     seroba_kmer: 'int',

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,6 +14,8 @@ params {
 
     // Default assembler
     assembler = "shovill"
+    // Default minimum contig length
+    min_contig_length = 500
 
     // Default git repository and local directory, and KMC kmer size for SeroBA 
     seroba_remote = "https://github.com/sanger-pathogens/seroba.git"

--- a/workflows/pipeline.nf
+++ b/workflows/pipeline.nf
@@ -37,11 +37,11 @@ workflow PIPELINE {
     // Output into Channel ASSEMBLY_ch, and hardlink the assemblies to $params.output directory
     switch (params.assembler) {
         case 'shovill':
-            ASSEMBLY_ch = ASSEMBLY_SHOVILL(PREPROCESS.out.processed_reads)
+            ASSEMBLY_ch = ASSEMBLY_SHOVILL(PREPROCESS.out.processed_reads, params.min_contig_length)
             break
 
         case 'unicycler':
-            ASSEMBLY_ch = ASSEMBLY_UNICYCLER(PREPROCESS.out.processed_reads)
+            ASSEMBLY_ch = ASSEMBLY_UNICYCLER(PREPROCESS.out.processed_reads, params.min_contig_length)
             break
     }
 


### PR DESCRIPTION
- Remove contigs that do not reach the minimum contig length target in the final assemblies (default to 500 bp, customisable, apply to both assemblers)
- Add minimum contig length information to `info.txt`
- Change assembly QC to consider all contigs in the final assemblies regardless of their lengths 